### PR TITLE
Allow `+` character in email addresses

### DIFF
--- a/lib/types/email.js
+++ b/lib/types/email.js
@@ -6,7 +6,7 @@ module.exports.loadType = function (mongoose) {
   function Email (path, options) {
     SchemaTypes.String.call(this, path, options);
     function validateEmail (val) {
-      return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/.test(val);
+      return /^[a-zA-Z0-9+._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/.test(val);
     }
     this.validate(validateEmail, 'email is invalid');
   }


### PR DESCRIPTION
As used by Google (http://support.google.com/mail/bin/answer.py?hl=en&answer=12096) or Facebook (app+XXXXX7c35a4aa26@proxymail.facebook.com).
