### PR TITLE
Include bson library and use its BinaryParser

### DIFF
--- a/lib/plugins/useTimestamps.js
+++ b/lib/plugins/useTimestamps.js
@@ -3,36 +3,16 @@ var mongoose = require('mongoose')
   , BinaryParser = require('bson').BinaryParser;
 
 exports.useTimestamps = function (schema, options) {
-  if (schema.path('_id')) {
-    schema.add({
-      updatedAt: Date
-    });
-    schema.virtual('createdAt')
-      .get( function () {
-        if (this._createdAt) return this._createdAt;
-        var unixtime = BinaryParser.decodeInt(this._id.id.slice(0, 4), 32, true, true);
-        return this._createdAt = new Date(unixtime * 1000);
-      });
-    schema.pre('save', function (next) {
-      if (this.isNew) {
-        this.updatedAt = this.createdAt;
-      } else {
-        this.updatedAt = new Date;
-      }
-      next();
-    });
-  } else {
-    schema.add({
-        createdAt: Date
-      , updatedAt: Date
-    });
-    schema.pre('save', function (next) {
-      if (!this.createdAt) {
-        this.createdAt = this.updatedAt = new Date;
-      } else {
-        this.updatedAt = new Date;
-      }
-      next();
-    });
-  }
+	schema.add({
+			createdAt: Date
+		, updatedAt: Date
+	});
+	schema.pre('save', function (next) {
+		if (!this.createdAt) {
+			this.createdAt = this.updatedAt = new Date;
+		} else {
+			this.updatedAt = new Date;
+		}
+		next();
+	});
 };

--- a/lib/plugins/useTimestamps.js
+++ b/lib/plugins/useTimestamps.js
@@ -1,6 +1,6 @@
 var mongoose = require('mongoose')
   , ObjectID = mongoose.ObjectID
-  , BinaryParser = require('bson').BinaryParser;
+	//, BinaryParser = require('bson').BinaryParser;
 
 exports.useTimestamps = function (schema, options) {
 	schema.add({

--- a/lib/plugins/useTimestamps.js
+++ b/lib/plugins/useTimestamps.js
@@ -1,6 +1,6 @@
 var mongoose = require('mongoose')
   , ObjectID = mongoose.ObjectID
-  , BinaryParser = mongoose.mongo.BinaryParser;
+  , BinaryParser = require('bson').BinaryParser;
 
 exports.useTimestamps = function (schema, options) {
   if (schema.path('_id')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name": "mongoose-types"
 , "description":  "More types for mongoose"
-, "version":  "1.0.3"
+, "version":  "1.0.3-2"
 , "author": "Brian Noguchi"
 , "dependencies": { "mongoose": ">= 1.0.16", "bson": ">= 0.0.4" }
 , "keywords": [ "mongoose", "mongo", "mongodb", "types" ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "description":  "More types for mongoose"
 , "version":  "1.0.3-2"
 , "author": "Brian Noguchi"
-, "dependencies": { "mongoose": ">= 1.0.16", "bson": ">= 0.0.4" }
+, "dependencies": { "mongoose": ">= 1.0.16" }
 , "keywords": [ "mongoose", "mongo", "mongodb", "types" ]
 , "scripts": { "test": "make test" }
 , "engines": { "node": ">= 0.1.101" }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "description":  "More types for mongoose"
 , "version":  "1.0.3"
 , "author": "Brian Noguchi"
-, "dependencies": { "mongoose": ">= 1.0.16"}
+, "dependencies": { "mongoose": ">= 1.0.16", "bson": ">= 0.0.4" }
 , "keywords": [ "mongoose", "mongo", "mongodb", "types" ]
 , "scripts": { "test": "make test" }
 , "engines": { "node": ">= 0.1.101" }


### PR DESCRIPTION
The mongo package no longer seems to include bson's BinaryParser, so the reference doesn't work anymore. Instead of relying on mongo, I thought it appropriate to include bson in this module instead.

Related to pull request #17, just a different way to fix the problem
