### PR TITLE
Changed the require statement of the mongoose  binaryParser

### DIFF
--- a/lib/plugins/useTimestamps.js
+++ b/lib/plugins/useTimestamps.js
@@ -1,6 +1,6 @@
 var mongoose = require('mongoose')
   , ObjectID = mongoose.ObjectID
-  , BinaryParser = mongoose.mongo.BinaryParser;
+  , BinaryParser = require('mongoose/node_modules/mongodb/node_modules/bson').BinaryParser;
 
 exports.useTimestamps = function (schema, options) {
   if (schema.path('_id')) {


### PR DESCRIPTION
After upgrading to a new mongoose version i had the problem that i got the message no function decodeInt. After changing the path of the require statement everything is fine again.
