### PR TITLE
fix for mongoose 3.0.0

### DIFF
--- a/lib/types/email.js
+++ b/lib/types/email.js
@@ -1,7 +1,13 @@
 var mongoose = require('mongoose')
 
 module.exports.loadType = function (mongoose) {
-  var SchemaTypes = mongoose.SchemaTypes;
+  if (typeof mongoose.SchemaTypes === 'object') {
+    // For mongoosejs < 3.0.0
+    var SchemaTypes = mongoose.SchemaTypes;
+  } else {
+    // For mongoosejs > 3.0.0
+    var SchemaTypes = mongoose.Schema.Types;
+  }
 
   function Email (path, options) {
     SchemaTypes.String.call(this, path, options);

--- a/lib/types/url.js
+++ b/lib/types/url.js
@@ -1,7 +1,13 @@
 var Url = require("url");
 
 module.exports.loadType = function (mongoose) {
-  var SchemaTypes = mongoose.SchemaTypes;
+  if (typeof mongoose.SchemaTypes === 'object') {
+    // For mongoosejs < 3.0.0
+    var SchemaTypes = mongoose.SchemaTypes;
+  } else {
+    // For mongoosejs > 3.0.0
+    var SchemaTypes = mongoose.Schema.Types;
+  }
 
   function Url (path, options) {
     SchemaTypes.String.call(this, path, options);


### PR DESCRIPTION
A small fix for mongoose 3.0.0

At the moment this code produce an error.

``` javascript
    var mongoose = require("mongoose");
    var db = mongoose.createConnection("mongodb://localhost/sampledb");
    var mongooseTypes = require("mongoose-types");
    mongooseTypes.loadTypes(mongoose);
```

```
/home/user/Repositories/my-mongoose-types/lib/types/url.js:14
  Url.prototype.__proto__ = SchemaTypes.String.prototype;
                                       ^
TypeError: Cannot read property 'String' of undefined
    at Object.loadType (/home/user/Repositories/my-mongoose-types/lib/types/url.js:14:40)
    at /home/user/Repositories/my-mongoose-types/lib/index.js:12:34
    at Array.forEach (native)
    at Object.loadTypes (/home/user/Repositories/my-mongoose-types/lib/index.js:10:11)
    at Object.<anonymous> (/home/user/Repositories/my-mongoose-types/t.js:4:15)
    at Module._compile (module.js:446:26)
    at Object..js (module.js:464:10)
    at Module.load (module.js:353:31)
    at Function._load (module.js:311:12)
    at Array.0 (module.js:484:10)
```
