### PR TITLE
Fixed query validation for empty query objects + Allow www in URL hostname

### DIFF
--- a/lib/types/url.js
+++ b/lib/types/url.js
@@ -36,6 +36,15 @@ module.exports.normalizeUrl = (function () {
     return querystr.join("&");
   };
 
+  var isEmpty = function (map) {
+    for(var key in map) {
+      if (map.hasOwnProperty(key)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   return function (uri) {
     var parsedUrl = Url.parse(uri, true)
       , urlstr = ""
@@ -44,12 +53,12 @@ module.exports.normalizeUrl = (function () {
       , pathname = parsedUrl.pathname
       , query = parsedUrl.query
       , hash = parsedUrl.hash;
-    urlstr += (protocol ? protocol.toLowerCase() : '') + "//" + (hostname ? hostname.toLowerCase().replace(/^www\./, "") : '') + // Convert scheme and host to lower case; remove www. if it exists in hostname
+    urlstr += (protocol ? protocol.toLowerCase() : '') + "//" + (hostname ? hostname.toLowerCase() : '') + // Convert scheme and host to lower case;
       (pathname ?
          pathname.replace(/\/\.{1,2}\//g, "/").replace(/\/{2,}/, "/") : // Remove dot-segments; Remove duplicate slashes
          "/" // Add trailing /
       );
-    if (query) {
+    if (!isEmpty(query)) {
       urlstr += "?" + reorderQuery(query);
     }
     if (hash) {


### PR DESCRIPTION
There was an error in the query validation function that attached the "?" prefix when query strings where present. Empty objects are parsed as true in the conditional if. I've fixed the validation, and also allowed www in the URL host, as some (misconfigured) hosts don't work when trying to reach them without the www.
